### PR TITLE
Git for Windows command for the curl installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ Installation with `curl`:
 curl -L -O https://raw.githubusercontent.com/SeedJobs/git-beam-it/master/git-beam-it && sudo mv git-beam-it /usr/local/bin/ && sudo chmod +x /usr/local/bin/git-beam-it
 ```
 
+Installation with 'curl' on 'Git for Windows'
+Create/Move to local directory within Git for Windows and run...
+```bash
+curl -L -O https://raw.githubusercontent.com/SeedJobs/git-beam-it/master/git-beam-it && chmod +x git-beam-it
+```
+...then run ./git-beam-it inside the same directory to execute script.
+
+
 Installation with `wget`:
 
 ```bash
@@ -40,6 +48,11 @@ sudo wget -P /usr/local/bin https://raw.githubusercontent.com/SeedJobs/git-beam-
 
 ```bash
 Usage: git beam-it <options>
+```
+
+Git for Windows Version:
+```bash
+Usage: ./git-beam-it <options>
 ```
 
 #### Options


### PR DESCRIPTION
Added a terminal command that will work in Git for Windows.
I understand it's just cutting out the Linux portions (binary and sudo), but it might serve well for the many bound to Windows and have never touched Linux. 
I'm especially interested in keeping this ready for myself since I know a few people that finished many class exercises and would like to bulk hide them upon its completion. _GitHub currently requires you to clone any forked repositories and hide them individually._